### PR TITLE
removing split mercs feature

### DIFF
--- a/common/ideas/war_country_ideas.txt
+++ b/common/ideas/war_country_ideas.txt
@@ -2981,7 +2981,6 @@ Z95_ideas = {
 A59_ideas = {
 	start = {
 		global_trade_power = 0.15
-		allow_mercenaries_to_split = yes
 	}
 
 	bonus = {


### PR DESCRIPTION
removed split mercs modifier from estalia, it doesnt work as per paradox says it does