### PR TITLE
Permanent claims for Dwarfs missions

### DIFF
--- a/missions/02_Dwarf_missions.txt
+++ b/missions/02_Dwarf_missions.txt
@@ -255,7 +255,7 @@ war_dwarf_faction_1 = {
 				}
 			}
 			grey_mountains_region = {
-				add_claim = ROOT
+				add_permanent_claim = ROOT
 			}
 		}
 	}
@@ -342,7 +342,7 @@ war_dwarf_faction_1 = {
 				}
 			}
 			black_mountains_region = {
-				add_claim = ROOT
+				add_permanent_claim = ROOT
 			}			
 		}
 	}
@@ -658,7 +658,7 @@ war_dwarf_faction_2 = {
 				}
 			}
 			world_edge_mountains_region = {
-				add_claim = ROOT
+				add_permanent_claim = ROOT
 			}
 		}
 	}
@@ -744,7 +744,7 @@ war_dwarf_faction_2 = {
 				}
 			}
 			world_edge_mountains_region = {
-				add_claim = ROOT
+				add_permanent_claim = ROOT
 			}			
 		}
 	}
@@ -1626,7 +1626,7 @@ war_dwarf_faction_4 = {
 				}		
 			}
 			karak_eight_peaks_region = {
-				add_claim = ROOT
+				add_permanent_claim = ROOT
 			}
 		}
 	}
@@ -1787,7 +1787,7 @@ war_dwarf_faction_4 = {
 				}
 			}
 			southern_world_edge_mountains_region = {
-				add_claim = ROOT
+				add_permanent_claim = ROOT
 			}			
 		}
 	}
@@ -2064,7 +2064,7 @@ war_dwarf_faction_5 = {
 				}
 			}
 			world_edge_mountains_region = {
-				add_claim = ROOT
+				add_permanent_claim = ROOT
 			}
 		}
 	}
@@ -2150,7 +2150,7 @@ war_dwarf_faction_5 = {
 				}
 			}
 			southern_world_edge_mountains_region = {
-				add_claim = ROOT
+				add_permanent_claim = ROOT
 			}			
 		}
 	}


### PR DESCRIPTION
Dwarfs hold grudges forever. 

It makes sense for their Reclaim missions on their lost holds to award Permanent claims instead of temporary ones.

~Great mod!